### PR TITLE
🏗️ feat: repositoriesクレートとUserRepositoryモック実装 #6

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -86,10 +86,7 @@ Your primary expertise includes:
    - Follow project-specific conventions from CLAUDE.md
    - Ensure code is testable and modular
 
-4. **Testing**:
-   - Create comprehensive test cases
-   - Consider edge cases and error conditions
-   - Verify performance characteristics
+4. **Testing**: [Delegated to tester agent (detailed below)]
 
 5. **Documentation**:
    - Add necessary inline documentation

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -109,6 +109,7 @@ You aim for:
 ### Execution Flow
 1. **Environment Setup**: Prepare dependencies and test data
 2. **Test Execution**: Run tests in appropriate order and groupings
+   - **Project Test Command**: Execute tests using `make test` from the project root directory
 3. **Result Analysis**: Identify root causes of failures
 4. **Report Generation**: Provide coverage and quality metrics
 5. **Improvement Proposals**: Suggest test suite optimizations

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Rust build artifacts
+**/target/
+**/*.log
+
+# Don't ignore Cargo.lock - it's needed for reproducible builds
+# **/*.lock  # Commented out to allow Cargo.lock
+
+# IDE files
+**/.vscode/
+**/.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Documentation
+README.md
+*.md
+
+# Temporary files
+**/*.tmp
+**/*.bak
+**/*~
+
+# Node.js (if any)
+**/node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,13 @@ Rust を用いて、GraphQL API を作成します。これは API テスト駆�
 
 ## ClaudeCodeAIAgent への指示
 - やり取りは日本語で行ってください。
+- コード作成・修正タスクでは必ず coder エージェントを使用してください
+- コードレビューが必要な場合は code-reviewer エージェントを使用してください
+- 複雑なタスクは適切な専門エージェントに委譲してください
+- 新しいコードを書く際は coder エージェント使用必須
+- バグ修正時は coder エージェント使用必須
+- リファクタリング時は coder エージェント使用必須
+- テスト作成時は tester エージェント使用必須
 
 ## プロジェクト要件
 1. GraphQL のリクエスト送信方法を学ぶため、学習用テスト(Learning Test)を書く。具体的には、[https://countries.trevorblades.com](https://countries.trevorblades.com/) に対する api テストを書く

--- a/application/Cargo.lock
+++ b/application/Cargo.lock
@@ -366,6 +366,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-graphql",
+ "repositories",
  "serde",
  "serde_json",
  "tokio",

--- a/application/Cargo.lock
+++ b/application/Cargo.lock
@@ -2342,6 +2342,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "repositories"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/application/Cargo.lock
+++ b/application/Cargo.lock
@@ -2345,6 +2345,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 name = "repositories"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "serde",
  "serde_json",

--- a/application/Cargo.lock
+++ b/application/Cargo.lock
@@ -2347,10 +2347,8 @@ name = "repositories"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chrono",
  "serde",
  "serde_json",
- "sqlx",
  "tokio",
 ]
 

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "api",
     "api_test",
-    "api_schema"
+    "api_schema",
+    "repositories"
 ]
 resolver = "2"

--- a/application/api_schema/Cargo.toml
+++ b/application/api_schema/Cargo.toml
@@ -9,5 +9,6 @@ tokio = { version = "1", features = ["full"] }
 async-graphql = "7.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+repositories = { path = "../repositories" }
 
 [dev-dependencies]

--- a/application/api_schema/src/lib.rs
+++ b/application/api_schema/src/lib.rs
@@ -1,4 +1,6 @@
 use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, SimpleObject, ID};
+use repositories::mock::user::UserRepositoryMock;
+use repositories::user::UserRepository;
 
 #[derive(SimpleObject)]
 struct User {
@@ -12,10 +14,12 @@ pub struct QueryRoot;
 #[Object]
 impl QueryRoot {
     async fn user(&self, _ctx: &Context<'_>, id: ID) -> User {
+        let repository = UserRepositoryMock;
+        let user = repository.fetch_by_id(id.parse::<i32>().unwrap()).unwrap();
         User {
-            id: id.to_string(),
-            name: "Alice Johnson".to_string(),
-            email: "alice@example.com".to_string(),
+            id: user.id.to_string(),
+            name: user.name,
+            email: user.email,
         }
     }
 }

--- a/application/api_schema/src/lib.rs
+++ b/application/api_schema/src/lib.rs
@@ -1,37 +1,32 @@
-use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, SimpleObject, ID};
+use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, ID};
 use anyhow::Result;
-use repositories::mock::user::UserRepositoryMock;
-use repositories::user::UserRepository;
 
-#[derive(SimpleObject)]
-struct User {
-    id: String,
-    name: String,
-    email: String,
+mod queries;
+use queries::user::{User, UserQuery};
+
+pub struct QueryRoot {
+    user_query: UserQuery,
 }
 
-pub struct QueryRoot;
+impl QueryRoot {
+    pub fn new() -> Self {
+        Self {
+            user_query: UserQuery,
+        }
+    }
+}
 
 #[Object]
 impl QueryRoot {
-    async fn user(&self, _ctx: &Context<'_>, id: ID) -> Result<User> {
-        let user_id = id.parse::<i32>()
-            .map_err(|_| anyhow::anyhow!("Invalid user ID format"))?;
-        
-        let repository = UserRepositoryMock;
-        let user = repository.fetch_by_id(user_id)?;
-        Ok(User {
-            id: user.id.to_string(),
-            name: user.name,
-            email: user.email,
-        })
+    async fn user(&self, ctx: &Context<'_>, id: ID) -> Result<User> {
+        self.user_query.user(ctx, id).await
     }
 }
 
 pub type GrSchema = async_graphql::Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
 pub fn build_schema() -> GrSchema {
-    async_graphql::Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish()
+    async_graphql::Schema::build(QueryRoot::new(), EmptyMutation, EmptySubscription).finish()
 }
 
 pub fn schema_sdl() -> String {
@@ -60,68 +55,4 @@ mod tests {
         assert!(schema.contains("query: QueryRoot"));
     }
 
-    #[tokio::test]
-    async fn test_fetch_user_query() {
-        let query = r#"
-            query {
-                user (id: "1") {
-                    id
-                    name
-                    email
-                }
-            }
-        "#;
-
-        let schema = build_schema();
-        let resp = schema.execute(query).await;
-
-        let respond_json = resp.data.into_json().unwrap();
-        let expected_json = serde_json::json!({
-            "user": {
-                "id": "1",
-                "name": "Alice Johnson",
-                "email": "alice@example.com"
-            }
-        });
-
-        assert_eq!(respond_json, expected_json);
-    }
-
-    #[tokio::test]
-    async fn test_user_query_with_invalid_id() {
-        let query = r#"
-            query {
-                user (id: "invalid") {
-                    id
-                    name
-                    email
-                }
-            }
-        "#;
-
-        let schema = build_schema();
-        let resp = schema.execute(query).await;
-
-        assert!(resp.errors.len() > 0);
-        assert!(resp.errors[0].message.contains("Invalid user ID format"));
-    }
-
-    #[tokio::test]
-    async fn test_user_query_with_nonexistent_id() {
-        let query = r#"
-            query {
-                user (id: "999") {
-                    id
-                    name
-                    email
-                }
-            }
-        "#;
-
-        let schema = build_schema();
-        let resp = schema.execute(query).await;
-
-        assert!(resp.errors.len() > 0);
-        assert!(resp.errors[0].message.contains("User not found"));
-    }
 }

--- a/application/api_schema/src/lib.rs
+++ b/application/api_schema/src/lib.rs
@@ -19,7 +19,7 @@ impl QueryRoot {
             .map_err(|_| anyhow::anyhow!("Invalid user ID format"))?;
         
         let repository = UserRepositoryMock;
-        let user = repository.fetch_by_id(user_id).unwrap();
+        let user = repository.fetch_by_id(user_id)?;
         Ok(User {
             id: user.id.to_string(),
             name: user.name,
@@ -104,5 +104,24 @@ mod tests {
 
         assert!(resp.errors.len() > 0);
         assert!(resp.errors[0].message.contains("Invalid user ID format"));
+    }
+
+    #[tokio::test]
+    async fn test_user_query_with_nonexistent_id() {
+        let query = r#"
+            query {
+                user (id: "999") {
+                    id
+                    name
+                    email
+                }
+            }
+        "#;
+
+        let schema = build_schema();
+        let resp = schema.execute(query).await;
+
+        assert!(resp.errors.len() > 0);
+        assert!(resp.errors[0].message.contains("User not found"));
     }
 }

--- a/application/api_schema/src/queries.rs
+++ b/application/api_schema/src/queries.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/application/api_schema/src/queries/user.rs
+++ b/application/api_schema/src/queries/user.rs
@@ -47,7 +47,7 @@ mod tests {
         let schema = build_schema();
         let resp = schema.execute(query).await;
 
-        let respond_json = resp.data.into_json().unwrap();
+        let respond_json = resp.data.into_json().expect("Failed to convert response data to JSON");
         let expected_json = serde_json::json!({
             "user": {
                 "id": "1",

--- a/application/api_schema/src/queries/user.rs
+++ b/application/api_schema/src/queries/user.rs
@@ -1,0 +1,99 @@
+use async_graphql::{Context, Object, SimpleObject, ID};
+use anyhow::Result;
+use repositories::mock::user::UserRepositoryMock;
+use repositories::user::UserRepository;
+
+#[derive(SimpleObject)]
+pub struct User {
+    pub id: String,
+    pub name: String,
+    pub email: String,
+}
+
+pub struct UserQuery;
+
+#[Object]
+impl UserQuery {
+    pub async fn user(&self, _ctx: &Context<'_>, id: ID) -> Result<User> {
+        let user_id = id.parse::<i32>()
+            .map_err(|_| anyhow::anyhow!("Invalid user ID format"))?;
+        
+        let repository = UserRepositoryMock;
+        let user = repository.fetch_by_id(user_id)?;
+        Ok(User {
+            id: user.id.to_string(),
+            name: user.name,
+            email: user.email,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::build_schema;
+
+    #[tokio::test]
+    async fn test_fetch_user_query() {
+        let query = r#"
+            query {
+                user (id: "1") {
+                    id
+                    name
+                    email
+                }
+            }
+        "#;
+
+        let schema = build_schema();
+        let resp = schema.execute(query).await;
+
+        let respond_json = resp.data.into_json().unwrap();
+        let expected_json = serde_json::json!({
+            "user": {
+                "id": "1",
+                "name": "Alice Johnson",
+                "email": "alice@example.com"
+            }
+        });
+
+        assert_eq!(respond_json, expected_json);
+    }
+
+    #[tokio::test]
+    async fn test_user_query_with_invalid_id() {
+        let query = r#"
+            query {
+                user (id: "invalid") {
+                    id
+                    name
+                    email
+                }
+            }
+        "#;
+
+        let schema = build_schema();
+        let resp = schema.execute(query).await;
+
+        assert!(resp.errors.len() > 0);
+        assert!(resp.errors[0].message.contains("Invalid user ID format"));
+    }
+
+    #[tokio::test]
+    async fn test_user_query_with_nonexistent_id() {
+        let query = r#"
+            query {
+                user (id: "999") {
+                    id
+                    name
+                    email
+                }
+            }
+        "#;
+
+        let schema = build_schema();
+        let resp = schema.execute(query).await;
+
+        assert!(resp.errors.len() > 0);
+        assert!(resp.errors[0].message.contains("User not found"));
+    }
+}

--- a/application/api_test/tests/db_integration_test.rs
+++ b/application/api_test/tests/db_integration_test.rs
@@ -22,7 +22,7 @@ async fn test_users_endpoint() -> Result<()> {
     assert!(json.is_array());
     
     // 少なくとも1人のユーザーが存在することを確認（テストデータから）
-    let users = json.as_array().unwrap();
+    let users = json.as_array().expect("Response should be an array");
     assert!(users.len() > 0);
     
     // 最初のユーザーの構造を確認

--- a/application/api_test/tests/graphql_api.rs
+++ b/application/api_test/tests/graphql_api.rs
@@ -12,7 +12,7 @@ async fn test_fetch_user() {
         .post("http://api:8080/graphql")
         .run_graphql(operation)
         .await
-        .unwrap();
+        .expect("Failed to execute GraphQL request");
 
     println!("Response: {:?}", resp);
 

--- a/application/bacon.toml
+++ b/application/bacon.toml
@@ -3,4 +3,4 @@ command = ["cargo", "run", "-p", "api"]
 need_stdout = true
 allow_warnings = true
 on_change_strategy = "kill_then_restart"
-watch = ["api/src", "api/Cargo.toml", "api_schema/src", "api_schema/Cargo.toml", "Cargo.toml"]
+watch = ["api/src", "api/Cargo.toml", "api_schema/src", "api_schema/Cargo.toml", "repositories/src", "repositories/Cargo.toml", "Cargo.toml"]

--- a/application/repositories/Cargo.toml
+++ b/application/repositories/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/application/repositories/Cargo.toml
+++ b/application/repositories/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "repositories"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "chrono"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/application/repositories/Cargo.toml
+++ b/application/repositories/Cargo.toml
@@ -8,5 +8,3 @@ anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "postgres", "chrono"] }
-chrono = { version = "0.4", features = ["serde"] }

--- a/application/repositories/src/db.rs
+++ b/application/repositories/src/db.rs
@@ -1,0 +1,1 @@
+pub mod models;

--- a/application/repositories/src/db.rs
+++ b/application/repositories/src/db.rs
@@ -1,1 +1,0 @@
-pub mod models;

--- a/application/repositories/src/db/models.rs
+++ b/application/repositories/src/db/models.rs
@@ -1,0 +1,5 @@
+pub struct User {
+    pub id: i32,
+    pub name: String,
+    pub email: String,
+}

--- a/application/repositories/src/lib.rs
+++ b/application/repositories/src/lib.rs
@@ -1,0 +1,13 @@
+fn four() -> i32 {
+    2 + 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(four(), 4);
+    }
+}

--- a/application/repositories/src/lib.rs
+++ b/application/repositories/src/lib.rs
@@ -5,17 +5,3 @@ mod db {
 mod mock {
     mod user;
 }
-
-fn four() -> i32 {
-    2 + 2
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        assert_eq!(four(), 4);
-    }
-}

--- a/application/repositories/src/lib.rs
+++ b/application/repositories/src/lib.rs
@@ -2,6 +2,8 @@ pub mod user;
 mod db {
     pub mod models;
 }
-mod mock {
-    mod user;
+
+// TODO リポジトリが実装されるまでモックを使う
+pub mod mock {
+    pub mod user;
 }

--- a/application/repositories/src/lib.rs
+++ b/application/repositories/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod user;
-mod db;
-mod mock;
+mod db {
+    pub mod models;
+}
+mod mock {
+    mod user;
+}
 
 fn four() -> i32 {
     2 + 2

--- a/application/repositories/src/lib.rs
+++ b/application/repositories/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod user;
 mod db;
+mod mock;
 
 fn four() -> i32 {
     2 + 2

--- a/application/repositories/src/lib.rs
+++ b/application/repositories/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod user;
+mod db;
 
 fn four() -> i32 {
     2 + 2

--- a/application/repositories/src/lib.rs
+++ b/application/repositories/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod user;
+
 fn four() -> i32 {
     2 + 2
 }

--- a/application/repositories/src/mock.rs
+++ b/application/repositories/src/mock.rs
@@ -1,0 +1,1 @@
+mod user;

--- a/application/repositories/src/mock.rs
+++ b/application/repositories/src/mock.rs
@@ -1,1 +1,0 @@
-mod user;

--- a/application/repositories/src/mock/user.rs
+++ b/application/repositories/src/mock/user.rs
@@ -22,7 +22,7 @@ mod tests {
 
     #[test]
     fn fetch_single_user() {
-        let user = UserRepositoryMock.fetch_by_id(1).unwrap();
+        let user = UserRepositoryMock.fetch_by_id(1).expect("Failed to fetch user with ID 1");
         assert_eq!(user.id, 1);
         assert_eq!(user.name, "Alice Johnson");
         assert_eq!(user.email, "alice@example.com");

--- a/application/repositories/src/mock/user.rs
+++ b/application/repositories/src/mock/user.rs
@@ -1,0 +1,30 @@
+use crate::{db::models::User, user::UserRepository};
+use anyhow::Result;
+
+pub struct UserRepositoryMock;
+impl UserRepository for UserRepositoryMock {
+    fn fetch_by_id(id: i32) -> Result<User> {
+        if id == 1 {
+            Ok(User {
+                id: 1,
+                name: "Alice Johnson".to_string(),
+                email: "alice@example.com".to_string(),
+            })
+        } else {
+            Err(anyhow::anyhow!("User not found"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_single_user() {
+        let user = UserRepositoryMock::fetch_by_id(1).unwrap();
+        assert_eq!(user.id, 1);
+        assert_eq!(user.name, "Alice Johnson");
+        assert_eq!(user.email, "alice@example.com");
+    }
+}

--- a/application/repositories/src/mock/user.rs
+++ b/application/repositories/src/mock/user.rs
@@ -11,7 +11,7 @@ impl UserRepository for UserRepositoryMock {
                 email: "alice@example.com".to_string(),
             })
         } else {
-            Err(anyhow::anyhow!("User not found"))
+            Err(anyhow::anyhow!("User with ID {} not found", id))
         }
     }
 }

--- a/application/repositories/src/mock/user.rs
+++ b/application/repositories/src/mock/user.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 
 pub struct UserRepositoryMock;
 impl UserRepository for UserRepositoryMock {
-    fn fetch_by_id(id: i32) -> Result<User> {
+    fn fetch_by_id(&self, id: i32) -> Result<User> {
         if id == 1 {
             Ok(User {
                 id: 1,
@@ -22,7 +22,7 @@ mod tests {
 
     #[test]
     fn fetch_single_user() {
-        let user = UserRepositoryMock::fetch_by_id(1).unwrap();
+        let user = UserRepositoryMock.fetch_by_id(1).unwrap();
         assert_eq!(user.id, 1);
         assert_eq!(user.name, "Alice Johnson");
         assert_eq!(user.email, "alice@example.com");

--- a/application/repositories/src/user.rs
+++ b/application/repositories/src/user.rs
@@ -1,0 +1,35 @@
+pub struct User {
+    pub id: i32,
+    pub name: String,
+    pub email: String,
+}
+
+pub struct UserRepository;
+impl UserRepository {
+    pub fn fetch_by_id(id: i32) -> Result<User, &'static str> {
+        // TODO DBからユーザ情報を取得する処理を実装
+        // モックデータ返却
+        if id == 1 {
+            Ok(User {
+                id: 1,
+                name: "Alice Johnson".to_string(),
+                email: "alice@example.com".to_string(),
+            })
+        } else {
+            Err("User not found")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_single_user() {
+        let user = UserRepository::fetch_by_id(1).unwrap();
+        assert_eq!(user.id, 1);
+        assert_eq!(user.name, "Alice Johnson");
+        assert_eq!(user.email, "alice@example.com");
+    }
+}

--- a/application/repositories/src/user.rs
+++ b/application/repositories/src/user.rs
@@ -1,31 +1,6 @@
 use crate::db::models::User;
+use anyhow::Result;
 
-pub struct UserRepository;
-impl UserRepository {
-    pub fn fetch_by_id(id: i32) -> Result<User, &'static str> {
-        // TODO DBからユーザ情報を取得する処理を実装
-        // モックデータ返却
-        if id == 1 {
-            Ok(User {
-                id: 1,
-                name: "Alice Johnson".to_string(),
-                email: "alice@example.com".to_string(),
-            })
-        } else {
-            Err("User not found")
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn fetch_single_user() {
-        let user = UserRepository::fetch_by_id(1).unwrap();
-        assert_eq!(user.id, 1);
-        assert_eq!(user.name, "Alice Johnson");
-        assert_eq!(user.email, "alice@example.com");
-    }
+pub trait UserRepository {
+    fn fetch_by_id(id: i32) -> Result<User>;
 }

--- a/application/repositories/src/user.rs
+++ b/application/repositories/src/user.rs
@@ -1,8 +1,4 @@
-pub struct User {
-    pub id: i32,
-    pub name: String,
-    pub email: String,
-}
+use crate::db::models::User;
 
 pub struct UserRepository;
 impl UserRepository {

--- a/application/repositories/src/user.rs
+++ b/application/repositories/src/user.rs
@@ -2,5 +2,5 @@ use crate::db::models::User;
 use anyhow::Result;
 
 pub trait UserRepository {
-    fn fetch_by_id(id: i32) -> Result<User>;
+    fn fetch_by_id(&self, id: i32) -> Result<User>;
 }

--- a/containers/api-test/Dockerfile
+++ b/containers/api-test/Dockerfile
@@ -11,6 +11,21 @@ RUN useradd -m -u 1000 -s /bin/bash testuser
 
 USER testuser
 
-COPY --chown=testuser:testuser application /app
+# 依存関係のキャッシュのためCargo.tomlとCargo.lockを先にコピー
+COPY --chown=testuser:testuser application/Cargo.toml application/Cargo.lock ./
+COPY --chown=testuser:testuser application/api_schema/Cargo.toml ./api_schema/
+COPY --chown=testuser:testuser application/api/Cargo.toml ./api/
+COPY --chown=testuser:testuser application/api_test/Cargo.toml ./api_test/
+
+# ダミーのsrc/lib.rsを作成して依存関係をビルド
+RUN mkdir -p api_schema/src api/src api_test/src && \
+    echo "fn main() {}" > api_schema/src/lib.rs && \
+    echo "fn main() {}" > api/src/main.rs && \
+    echo "fn main() {}" > api_test/src/main.rs && \
+    cargo build --workspace --tests && \
+    rm -rf api_schema/src api/src api_test/src
+
+# 実際のソースコードをコピー
+COPY --chown=testuser:testuser application/ ./
 
 CMD ["cargo", "test", "--workspace"]

--- a/containers/api-test/Dockerfile
+++ b/containers/api-test/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -u 1000 -s /bin/bash testuser
+RUN useradd -m -u 1000 -s /bin/bash testuser && \
+    chown -R testuser:testuser /app
 
 USER testuser
 
@@ -16,16 +17,20 @@ COPY --chown=testuser:testuser application/Cargo.toml application/Cargo.lock ./
 COPY --chown=testuser:testuser application/api_schema/Cargo.toml ./api_schema/
 COPY --chown=testuser:testuser application/api/Cargo.toml ./api/
 COPY --chown=testuser:testuser application/api_test/Cargo.toml ./api_test/
+COPY --chown=testuser:testuser application/repositories/Cargo.toml ./repositories/
 
 # ダミーのsrc/lib.rsを作成して依存関係をビルド
-RUN mkdir -p api_schema/src api/src api_test/src && \
+RUN mkdir -p api_schema/src api/src api_test/src repositories/src && \
     echo "fn main() {}" > api_schema/src/lib.rs && \
     echo "fn main() {}" > api/src/main.rs && \
     echo "fn main() {}" > api_test/src/main.rs && \
+    echo "fn main() {}" > repositories/src/lib.rs && \
     cargo build --workspace --tests && \
-    rm -rf api_schema/src api/src api_test/src
+    rm -rf api_schema/src api/src api_test/src repositories/src
 
-# 実際のソースコードをコピー
-COPY --chown=testuser:testuser application/ ./
+# 必要なソースコードのみをコピー（テストに必要な部分のみ）
+COPY --chown=testuser:testuser application/api_schema/ ./api_schema/
+COPY --chown=testuser:testuser application/api_test/ ./api_test/
+COPY --chown=testuser:testuser application/repositories/ ./repositories/
 
 CMD ["cargo", "test", "--workspace"]

--- a/containers/api-test/Dockerfile
+++ b/containers/api-test/Dockerfile
@@ -12,8 +12,8 @@ RUN useradd -m -u 1000 -s /bin/bash testuser && \
 
 USER testuser
 
-# 依存関係のキャッシュのためCargo.tomlとCargo.lockを先にコピー
-COPY --chown=testuser:testuser application/Cargo.toml application/Cargo.lock ./
+# 依存関係のキャッシュのためCargo.toml（とCargo.lockがあれば）を先にコピー
+COPY --chown=testuser:testuser application/Cargo.* ./
 COPY --chown=testuser:testuser application/api_schema/Cargo.toml ./api_schema/
 COPY --chown=testuser:testuser application/api/Cargo.toml ./api/
 COPY --chown=testuser:testuser application/api_test/Cargo.toml ./api_test/
@@ -21,16 +21,16 @@ COPY --chown=testuser:testuser application/repositories/Cargo.toml ./repositorie
 
 # ダミーのsrc/lib.rsを作成して依存関係をビルド
 RUN mkdir -p api_schema/src api/src api_test/src repositories/src && \
-    echo "fn main() {}" > api_schema/src/lib.rs && \
+    echo "pub fn dummy() {}" > api_schema/src/lib.rs && \
     echo "fn main() {}" > api/src/main.rs && \
     echo "fn main() {}" > api_test/src/main.rs && \
-    echo "fn main() {}" > repositories/src/lib.rs && \
+    echo "pub fn dummy() {}" > repositories/src/lib.rs && \
     cargo build --workspace --tests && \
     rm -rf api_schema/src api/src api_test/src repositories/src
 
-# 必要なソースコードのみをコピー（テストに必要な部分のみ）
-COPY --chown=testuser:testuser application/api_schema/ ./api_schema/
-COPY --chown=testuser:testuser application/api_test/ ./api_test/
-COPY --chown=testuser:testuser application/repositories/ ./repositories/
+# 必要なソースコードのみをコピー（ソースコードディレクトリのみ）
+COPY --chown=testuser:testuser application/api_schema/src/ ./api_schema/src/
+COPY --chown=testuser:testuser application/api_test/src/ ./api_test/src/
+COPY --chown=testuser:testuser application/repositories/src/ ./repositories/src/
 
 CMD ["cargo", "test", "--workspace"]

--- a/containers/api/Dockerfile
+++ b/containers/api/Dockerfile
@@ -14,9 +14,22 @@ USER apiuser
 
 RUN cargo install bacon
 
-COPY --chown=apiuser:apiuser application /app
+# 依存関係のキャッシュのためCargo.tomlとCargo.lockを先にコピー
+COPY --chown=apiuser:apiuser application/Cargo.toml application/Cargo.lock ./
+COPY --chown=apiuser:apiuser application/api_schema/Cargo.toml ./api_schema/
+COPY --chown=apiuser:apiuser application/api/Cargo.toml ./api/
+COPY --chown=apiuser:apiuser application/api_test/Cargo.toml ./api_test/
 
-WORKDIR /app
+# ダミーのsrc/lib.rsを作成して依存関係をビルド
+RUN mkdir -p api_schema/src api/src api_test/src && \
+    echo "fn main() {}" > api_schema/src/lib.rs && \
+    echo "fn main() {}" > api/src/main.rs && \
+    echo "fn main() {}" > api_test/src/main.rs && \
+    cargo build --workspace && \
+    rm -rf api_schema/src api/src api_test/src
+
+# 実際のソースコードをコピー
+COPY --chown=apiuser:apiuser application/ ./
 
 EXPOSE 8080
 

--- a/containers/api/Dockerfile
+++ b/containers/api/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -u 1000 -s /bin/bash apiuser
+RUN useradd -m -u 1000 -s /bin/bash apiuser && \
+    chown -R apiuser:apiuser /app
 
 USER apiuser
 
@@ -19,17 +20,21 @@ COPY --chown=apiuser:apiuser application/Cargo.toml application/Cargo.lock ./
 COPY --chown=apiuser:apiuser application/api_schema/Cargo.toml ./api_schema/
 COPY --chown=apiuser:apiuser application/api/Cargo.toml ./api/
 COPY --chown=apiuser:apiuser application/api_test/Cargo.toml ./api_test/
+COPY --chown=apiuser:apiuser application/repositories/Cargo.toml ./repositories/
 
 # ダミーのsrc/lib.rsを作成して依存関係をビルド
-RUN mkdir -p api_schema/src api/src api_test/src && \
+RUN mkdir -p api_schema/src api/src api_test/src repositories/src && \
     echo "fn main() {}" > api_schema/src/lib.rs && \
     echo "fn main() {}" > api/src/main.rs && \
     echo "fn main() {}" > api_test/src/main.rs && \
+    echo "fn main() {}" > repositories/src/lib.rs && \
     cargo build --workspace && \
-    rm -rf api_schema/src api/src api_test/src
+    rm -rf api_schema/src api/src api_test/src repositories/src
 
-# 実際のソースコードをコピー
-COPY --chown=apiuser:apiuser application/ ./
+# 必要なソースコードのみをコピー（apiクレートに必要な部分のみ）
+COPY --chown=apiuser:apiuser application/api_schema/ ./api_schema/
+COPY --chown=apiuser:apiuser application/api/ ./api/
+COPY --chown=apiuser:apiuser application/repositories/ ./repositories/
 
 EXPOSE 8080
 

--- a/containers/api/Dockerfile
+++ b/containers/api/Dockerfile
@@ -6,35 +6,37 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     curl \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 
 RUN useradd -m -u 1000 -s /bin/bash apiuser && \
     chown -R apiuser:apiuser /app
 
 USER apiuser
 
-RUN cargo install bacon
+# baconを軽量化：cargo-watchの代替として最小限のインストール
+RUN cargo install bacon --no-default-features
 
-# 依存関係のキャッシュのためCargo.tomlとCargo.lockを先にコピー
-COPY --chown=apiuser:apiuser application/Cargo.toml application/Cargo.lock ./
+# 依存関係のキャッシュのためCargo.toml（とCargo.lockがあれば）を先にコピー
+COPY --chown=apiuser:apiuser application/Cargo.* ./
 COPY --chown=apiuser:apiuser application/api_schema/Cargo.toml ./api_schema/
 COPY --chown=apiuser:apiuser application/api/Cargo.toml ./api/
 COPY --chown=apiuser:apiuser application/api_test/Cargo.toml ./api_test/
 COPY --chown=apiuser:apiuser application/repositories/Cargo.toml ./repositories/
 
-# ダミーのsrc/lib.rsを作成して依存関係をビルド
+# ダミーのsrc/lib.rsを作成して依存関係をビルド（デバッグ用）
 RUN mkdir -p api_schema/src api/src api_test/src repositories/src && \
-    echo "fn main() {}" > api_schema/src/lib.rs && \
+    echo "pub fn dummy() {}" > api_schema/src/lib.rs && \
     echo "fn main() {}" > api/src/main.rs && \
     echo "fn main() {}" > api_test/src/main.rs && \
-    echo "fn main() {}" > repositories/src/lib.rs && \
+    echo "pub fn dummy() {}" > repositories/src/lib.rs && \
     cargo build --workspace && \
     rm -rf api_schema/src api/src api_test/src repositories/src
 
-# 必要なソースコードのみをコピー（apiクレートに必要な部分のみ）
-COPY --chown=apiuser:apiuser application/api_schema/ ./api_schema/
-COPY --chown=apiuser:apiuser application/api/ ./api/
-COPY --chown=apiuser:apiuser application/repositories/ ./repositories/
+# 必要なソースコードのみをコピー（ソースコードディレクトリのみ）
+COPY --chown=apiuser:apiuser application/api_schema/src/ ./api_schema/src/
+COPY --chown=apiuser:apiuser application/api/src/ ./api/src/
+COPY --chown=apiuser:apiuser application/repositories/src/ ./repositories/src/
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Issue

- resolve: #6

## なぜこの変更が必要なのか？

GraphQL APIのリポジトリ層を実装するため、repositoriesクレートとUserRepositoryの基本構造を作成しました。現在はモック実装を使用して、後の実際のDB実装への移行を容易にしています。

## 変更内容

### 新しいrepositoriesクレート
- UserRepositoryトレイトの定義
- UserRepositoryMockの実装
- DBモデルの構造定義

### api_schemaとの統合
- UserRepositoryMockを使用したユーザーデータ取得
- GraphQLクエリでモックデータを返却

### Dockerファイルの最適化
- 依存関係キャッシュの改善でビルド時間短縮
- コンテナサイズの削減
- 権限問題の修正

## テスト計画

- [x] UserRepositoryMockの単体テスト
- [x] api_schemaでのモックデータ取得動作確認
- [x] Dockerビルドの成功確認

🤖 Generated with [Claude Code](https://claude.ai/code)